### PR TITLE
Extend Archivo API with vM (versionMatching) paramter

### DIFF
--- a/archivo/querying/query_databus.py
+++ b/archivo/querying/query_databus.py
@@ -133,7 +133,7 @@ def find_previous_version(versions, target_file, target_version):
 def find_closest_version(versions, target_file, target_version):
     target_datetime = datetime.strptime(target_version, '%Y.%m.%d-%H%M%S')
     closest_version = None
-    min_diff = float('inf')  # Initialize to infinity
+    min_diff = float('inf')
     
     for version_dict in versions:
         if target_file in version_dict['file']['value']:

--- a/archivo/webservice/routes.py
+++ b/archivo/webservice/routes.py
@@ -336,6 +336,7 @@ def download_ontology():
     ontoUri = args.get("o", "")
     rdfFormat = args.get("f", "owl")
     version = args.get("v", None)
+    versionMatching = args.get('vM', 'snapshotVersionString')
     ontoUri = unquote(ontoUri)
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     isDev = True if "dev" in args else False
@@ -345,6 +346,7 @@ def download_ontology():
         version=version,
         rdf_format=rdfFormat,
         source_schema=scheme,
+        versionMatching=versionMatching
     )
 
 
@@ -407,7 +409,7 @@ def getCorrectScheme(scheme):
 
 
 def download_handling(
-    uri, is_dev=False, version="", rdf_format="owl", source_schema="http"
+    uri, is_dev=False, version="", rdf_format="owl", source_schema="http", versionMatching='snapshotVersionString'
 ):
     ontoUri = unquote(uri)
     foundURI = string_tools.get_uri_from_index(
@@ -420,7 +422,7 @@ def download_handling(
     )
     try:
         downloadLink = query_databus.get_download_url(
-            group, artifact, file_extension=rdf_format, version=version
+            group, artifact, file_extension=rdf_format, version=version, versionMatching=versionMatching
         )
     except URLError as e:
         abort(

--- a/archivo/webservice/routes.py
+++ b/archivo/webservice/routes.py
@@ -336,7 +336,7 @@ def download_ontology():
     ontoUri = args.get("o", "")
     rdfFormat = args.get("f", "owl")
     version = args.get("v", None)
-    versionMatching = args.get('vM', 'snapshotVersionString')
+    versionMatching = args.get("vM", "default")
     ontoUri = unquote(ontoUri)
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     isDev = True if "dev" in args else False
@@ -346,7 +346,7 @@ def download_ontology():
         version=version,
         rdf_format=rdfFormat,
         source_schema=scheme,
-        versionMatching=versionMatching
+        versionMatching=versionMatching,
     )
 
 
@@ -358,12 +358,14 @@ def turtle_ont_download():
     isDev = True if "dev" in args else False
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     version = args.get("v", None)
+    versionMatching = args.get("vM", "default")
     return download_handling(
         uri=ontoUri,
         is_dev=isDev,
         version=version,
         rdf_format=rdfFormat,
         source_schema=scheme,
+        versionMatching=versionMatching,
     )
 
 
@@ -375,12 +377,14 @@ def rdfxml_ont_download():
     isDev = True if "dev" in args else False
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     version = args.get("v", None)
+    versionMatching = args.get("vM", "default")
     return download_handling(
         uri=ontoUri,
         is_dev=isDev,
         version=version,
         rdf_format=rdfFormat,
         source_schema=scheme,
+        versionMatching=versionMatching,
     )
 
 
@@ -390,6 +394,7 @@ def ntriples_ont_download():
     ontoUri = args.get("o", "")
     rdfFormat = args.get("f", "nt")
     version = args.get("v", None)
+    versionMatching = args.get("vM", "default")
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     isDev = True if "dev" in args else False
     return download_handling(
@@ -398,6 +403,7 @@ def ntriples_ont_download():
         version=version,
         rdf_format=rdfFormat,
         source_schema=scheme,
+        versionMatching=versionMatching,
     )
 
 
@@ -409,7 +415,7 @@ def getCorrectScheme(scheme):
 
 
 def download_handling(
-    uri, is_dev=False, version="", rdf_format="owl", source_schema="http", versionMatching='snapshotVersionString'
+    uri, is_dev=False, version="", rdf_format="owl", source_schema="http", versionMatching='default'
 ):
     ontoUri = unquote(uri)
     foundURI = string_tools.get_uri_from_index(

--- a/archivo/webservice/routes.py
+++ b/archivo/webservice/routes.py
@@ -336,7 +336,7 @@ def download_ontology():
     ontoUri = args.get("o", "")
     rdfFormat = args.get("f", "owl")
     version = args.get("v", None)
-    versionMatching = args.get("vM", "default")
+    versionMatching = args.get("vM", "closest")
     ontoUri = unquote(ontoUri)
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     isDev = True if "dev" in args else False
@@ -358,7 +358,7 @@ def turtle_ont_download():
     isDev = True if "dev" in args else False
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     version = args.get("v", None)
-    versionMatching = args.get("vM", "default")
+    versionMatching = args.get("vM", "closest")
     return download_handling(
         uri=ontoUri,
         is_dev=isDev,
@@ -377,7 +377,7 @@ def rdfxml_ont_download():
     isDev = True if "dev" in args else False
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     version = args.get("v", None)
-    versionMatching = args.get("vM", "default")
+    versionMatching = args.get("vM", "closest")
     return download_handling(
         uri=ontoUri,
         is_dev=isDev,
@@ -394,7 +394,7 @@ def ntriples_ont_download():
     ontoUri = args.get("o", "")
     rdfFormat = args.get("f", "nt")
     version = args.get("v", None)
-    versionMatching = args.get("vM", "default")
+    versionMatching = args.get("vM", "closest")
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     isDev = True if "dev" in args else False
     return download_handling(
@@ -415,7 +415,7 @@ def getCorrectScheme(scheme):
 
 
 def download_handling(
-    uri, is_dev=False, version="", rdf_format="owl", source_schema="http", versionMatching='default'
+    uri, is_dev=False, version="", rdf_format="owl", source_schema="http", versionMatching='closest'
 ):
     ontoUri = unquote(uri)
     foundURI = string_tools.get_uri_from_index(


### PR DESCRIPTION
3 possible values:
- 'default': exact Archivo Snapshot Version Identifier (matches Databus version format)
- 'before': retrieves the version snapshot that was archived last before the given timestamp
- 'closest': (default value as this is the most stable) retrieves the version snapshot that was archived on the dateTime closest (least time difference) to given timestamp