### PR TITLE
Extend Archivo API with vM (versionMatching) paramter

### DIFF
--- a/archivo/querying/query_databus.py
+++ b/archivo/querying/query_databus.py
@@ -208,11 +208,13 @@ def get_download_url(
                 previous_version = find_previous_version(versions, group, version)
                 queryString.extend(["   ?dataset dct:hasVersion '%s'." % previous_version])
 
+            if versionMatching == 'beforeOrClosest':
+                previous_version = find_previous_version(versions, group, version)
                 # In case there is no version before, fall back to the the closest version
-                # if previous_version:
-                #     queryString.extend(["   ?dataset dct:hasVersion '%s'." % previous_version])
-                # else:
-                #     versionMatching = 'closest'
+                if previous_version:
+                    queryString.extend(["   ?dataset dct:hasVersion '%s'." % previous_version])
+                else:
+                    versionMatching = 'closest'
 
             if versionMatching == 'closest':
                 closest_version = find_closest_version(versions, group, version)

--- a/archivo/querying/query_databus.py
+++ b/archivo/querying/query_databus.py
@@ -149,7 +149,7 @@ def find_closest_version(versions, target_file, target_version):
 
 
 def get_download_url(
-    group: str, artifact: str, file_extension: str = "owl", version: str = None, versionMatching: str = 'closest'
+    group: str, artifact: str, file_extension: str = "owl", version: str = None, versionMatching: str = 'default'
 ) -> Optional[str]:
 
     artifact_id = f"{archivo_config.DATABUS_BASE}/{archivo_config.DATABUS_USER}/{group}/{artifact}"
@@ -180,6 +180,8 @@ def get_download_url(
         if versionMatching == 'default':
             queryString.extend(["   ?dataset dct:hasVersion '%s'." % version])
         else:
+            # Fetching all the version because timestamp comparison 
+            # with SPARQL was not working as expected
             queryAvailableVersions = [
                 query_templates.general_purpose_prefixes,
                 "",
@@ -204,15 +206,17 @@ def get_download_url(
 
             if versionMatching == 'before':
                 previous_version = find_previous_version(versions, group, version)
+                queryString.extend(["   ?dataset dct:hasVersion '%s'." % previous_version])
 
-                if previous_version:
-                    queryString.extend(["   ?dataset dct:hasVersion '%s'." % previous_version])
-                else:
-                    versionMatching = 'closest'
+                # In case there is no version before, fall back to the the closest version
+                # if previous_version:
+                #     queryString.extend(["   ?dataset dct:hasVersion '%s'." % previous_version])
+                # else:
+                #     versionMatching = 'closest'
 
             if versionMatching == 'closest':
-                    closest_version = find_closest_version(versions, group, version)
-                    queryString.extend(["   ?dataset dct:hasVersion '%s'." % closest_version])
+                closest_version = find_closest_version(versions, group, version)
+                queryString.extend(["   ?dataset dct:hasVersion '%s'." % closest_version])
 
     queryString.append("}")
 

--- a/archivo/querying/query_databus.py
+++ b/archivo/querying/query_databus.py
@@ -149,7 +149,7 @@ def find_closest_version(versions, target_file, target_version):
 
 
 def get_download_url(
-    group: str, artifact: str, file_extension: str = "owl", version: str = None, versionMatching: str = 'default'
+    group: str, artifact: str, file_extension: str = "owl", version: str = None, versionMatching: str = 'exact'
 ) -> Optional[str]:
 
     artifact_id = f"{archivo_config.DATABUS_BASE}/{archivo_config.DATABUS_USER}/{group}/{artifact}"
@@ -177,7 +177,7 @@ def get_download_url(
             ]
         )
     else:
-        if versionMatching == 'default':
+        if versionMatching == 'exact':
             queryString.extend(["   ?dataset dct:hasVersion '%s'." % version])
         else:
             # Fetching all the version because timestamp comparison 

--- a/archivo/querying/query_databus.py
+++ b/archivo/querying/query_databus.py
@@ -133,7 +133,7 @@ def find_previous_version(versions, target_file, target_version):
 def find_closest_version(versions, target_file, target_version):
     target_datetime = datetime.strptime(target_version, '%Y.%m.%d-%H%M%S')
     closest_version = None
-    min_diff = float('inf')  # Initialize to infinity
+    min_diff = float('inf')
     
     for version_dict in versions:
         if target_file in version_dict['file']['value']:

--- a/archivo/webservice/routes.py
+++ b/archivo/webservice/routes.py
@@ -336,6 +336,7 @@ def download_ontology():
     ontoUri = args.get("o", "")
     rdfFormat = args.get("f", "owl")
     version = args.get("v", None)
+    versionMatching = args.get('vM', 'snapshotVersionString')
     ontoUri = unquote(ontoUri)
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     isDev = True if "dev" in args else False
@@ -345,6 +346,7 @@ def download_ontology():
         version=version,
         rdf_format=rdfFormat,
         source_schema=scheme,
+        versionMatching=versionMatching
     )
 
 
@@ -407,7 +409,7 @@ def getCorrectScheme(scheme):
 
 
 def download_handling(
-    uri, is_dev=False, version="", rdf_format="owl", source_schema="http"
+    uri, is_dev=False, version="", rdf_format="owl", source_schema="http", versionMatching='snapshotVersionString'
 ):
     ontoUri = unquote(uri)
     foundURI = string_tools.get_uri_from_index(
@@ -420,7 +422,7 @@ def download_handling(
     )
     try:
         downloadLink = query_databus.get_download_url(
-            group, artifact, file_extension=rdf_format, version=version
+            group, artifact, file_extension=rdf_format, version=version, versionMatching=versionMatching
         )
     except URLError as e:
         abort(

--- a/archivo/webservice/routes.py
+++ b/archivo/webservice/routes.py
@@ -394,7 +394,7 @@ def ntriples_ont_download():
     ontoUri = args.get("o", "")
     rdfFormat = args.get("f", "nt")
     version = args.get("v", None)
-    versionMatching = args.get("vM", "closest")
+    versionMatching = args.get("vM", "default")
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     isDev = True if "dev" in args else False
     return download_handling(
@@ -415,7 +415,7 @@ def getCorrectScheme(scheme):
 
 
 def download_handling(
-    uri, is_dev=False, version="", rdf_format="owl", source_schema="http", versionMatching='closest'
+    uri, is_dev=False, version="", rdf_format="owl", source_schema="http", versionMatching="default"
 ):
     ontoUri = unquote(uri)
     foundURI = string_tools.get_uri_from_index(

--- a/archivo/webservice/routes.py
+++ b/archivo/webservice/routes.py
@@ -336,7 +336,7 @@ def download_ontology():
     ontoUri = args.get("o", "")
     rdfFormat = args.get("f", "owl")
     version = args.get("v", None)
-    versionMatching = args.get("vM", "closest")
+    versionMatching = args.get("vM", "default")
     ontoUri = unquote(ontoUri)
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     isDev = True if "dev" in args else False
@@ -358,7 +358,7 @@ def turtle_ont_download():
     isDev = True if "dev" in args else False
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     version = args.get("v", None)
-    versionMatching = args.get("vM", "closest")
+    versionMatching = args.get("vM", "default")
     return download_handling(
         uri=ontoUri,
         is_dev=isDev,
@@ -377,7 +377,7 @@ def rdfxml_ont_download():
     isDev = True if "dev" in args else False
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     version = args.get("v", None)
-    versionMatching = args.get("vM", "closest")
+    versionMatching = args.get("vM", "default")
     return download_handling(
         uri=ontoUri,
         is_dev=isDev,

--- a/archivo/webservice/routes.py
+++ b/archivo/webservice/routes.py
@@ -336,7 +336,7 @@ def download_ontology():
     ontoUri = args.get("o", "")
     rdfFormat = args.get("f", "owl")
     version = args.get("v", None)
-    versionMatching = args.get('vM', 'snapshotVersionString')
+    versionMatching = args.get("vM", "default")
     ontoUri = unquote(ontoUri)
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     isDev = True if "dev" in args else False
@@ -346,7 +346,7 @@ def download_ontology():
         version=version,
         rdf_format=rdfFormat,
         source_schema=scheme,
-        versionMatching=versionMatching
+        versionMatching=versionMatching,
     )
 
 
@@ -358,12 +358,14 @@ def turtle_ont_download():
     isDev = True if "dev" in args else False
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     version = args.get("v", None)
+    versionMatching = args.get("vM", "default")
     return download_handling(
         uri=ontoUri,
         is_dev=isDev,
         version=version,
         rdf_format=rdfFormat,
         source_schema=scheme,
+        versionMatching=versionMatching,
     )
 
 
@@ -375,12 +377,14 @@ def rdfxml_ont_download():
     isDev = True if "dev" in args else False
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     version = args.get("v", None)
+    versionMatching = args.get("vM", "default")
     return download_handling(
         uri=ontoUri,
         is_dev=isDev,
         version=version,
         rdf_format=rdfFormat,
         source_schema=scheme,
+        versionMatching=versionMatching,
     )
 
 
@@ -390,6 +394,7 @@ def ntriples_ont_download():
     ontoUri = args.get("o", "")
     rdfFormat = args.get("f", "nt")
     version = args.get("v", None)
+    versionMatching = args.get("vM", "default")
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     isDev = True if "dev" in args else False
     return download_handling(
@@ -398,6 +403,7 @@ def ntriples_ont_download():
         version=version,
         rdf_format=rdfFormat,
         source_schema=scheme,
+        versionMatching=versionMatching,
     )
 
 
@@ -409,7 +415,7 @@ def getCorrectScheme(scheme):
 
 
 def download_handling(
-    uri, is_dev=False, version="", rdf_format="owl", source_schema="http", versionMatching='snapshotVersionString'
+    uri, is_dev=False, version="", rdf_format="owl", source_schema="http", versionMatching='default'
 ):
     ontoUri = unquote(uri)
     foundURI = string_tools.get_uri_from_index(

--- a/archivo/webservice/routes.py
+++ b/archivo/webservice/routes.py
@@ -336,7 +336,7 @@ def download_ontology():
     ontoUri = args.get("o", "")
     rdfFormat = args.get("f", "owl")
     version = args.get("v", None)
-    versionMatching = args.get("vM", "default")
+    versionMatching = args.get("vM", "exact")
     ontoUri = unquote(ontoUri)
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     isDev = True if "dev" in args else False
@@ -358,7 +358,7 @@ def turtle_ont_download():
     isDev = True if "dev" in args else False
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     version = args.get("v", None)
-    versionMatching = args.get("vM", "default")
+    versionMatching = args.get("vM", "exact")
     return download_handling(
         uri=ontoUri,
         is_dev=isDev,
@@ -377,7 +377,7 @@ def rdfxml_ont_download():
     isDev = True if "dev" in args else False
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     version = args.get("v", None)
-    versionMatching = args.get("vM", "default")
+    versionMatching = args.get("vM", "exact")
     return download_handling(
         uri=ontoUri,
         is_dev=isDev,
@@ -394,7 +394,7 @@ def ntriples_ont_download():
     ontoUri = args.get("o", "")
     rdfFormat = args.get("f", "nt")
     version = args.get("v", None)
-    versionMatching = args.get("vM", "default")
+    versionMatching = args.get("vM", "exact")
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     isDev = True if "dev" in args else False
     return download_handling(
@@ -415,7 +415,7 @@ def getCorrectScheme(scheme):
 
 
 def download_handling(
-    uri, is_dev=False, version="", rdf_format="owl", source_schema="http", versionMatching="default"
+    uri, is_dev=False, version="", rdf_format="owl", source_schema="http", versionMatching="exact"
 ):
     ontoUri = unquote(uri)
     foundURI = string_tools.get_uri_from_index(

--- a/archivo/webservice/routes.py
+++ b/archivo/webservice/routes.py
@@ -336,7 +336,7 @@ def download_ontology():
     ontoUri = args.get("o", "")
     rdfFormat = args.get("f", "owl")
     version = args.get("v", None)
-    versionMatching = args.get("vM", "default")
+    versionMatching = args.get("vM", "closest")
     ontoUri = unquote(ontoUri)
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     isDev = True if "dev" in args else False
@@ -358,7 +358,7 @@ def turtle_ont_download():
     isDev = True if "dev" in args else False
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     version = args.get("v", None)
-    versionMatching = args.get("vM", "default")
+    versionMatching = args.get("vM", "closest")
     return download_handling(
         uri=ontoUri,
         is_dev=isDev,
@@ -377,7 +377,7 @@ def rdfxml_ont_download():
     isDev = True if "dev" in args else False
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     version = args.get("v", None)
-    versionMatching = args.get("vM", "default")
+    versionMatching = args.get("vM", "closest")
     return download_handling(
         uri=ontoUri,
         is_dev=isDev,
@@ -394,7 +394,7 @@ def ntriples_ont_download():
     ontoUri = args.get("o", "")
     rdfFormat = args.get("f", "nt")
     version = args.get("v", None)
-    versionMatching = args.get("vM", "default")
+    versionMatching = args.get("vM", "closest")
     scheme = getCorrectScheme(request.headers.get("X-Forwarded-Proto"))
     isDev = True if "dev" in args else False
     return download_handling(
@@ -415,7 +415,7 @@ def getCorrectScheme(scheme):
 
 
 def download_handling(
-    uri, is_dev=False, version="", rdf_format="owl", source_schema="http", versionMatching='default'
+    uri, is_dev=False, version="", rdf_format="owl", source_schema="http", versionMatching='closest'
 ):
     ontoUri = unquote(uri)
     foundURI = string_tools.get_uri_from_index(


### PR DESCRIPTION
3 possible values:

'default': exact Archivo Snapshot Version Identifier (matches Databus version format)
'before': retrieves the version snapshot that was archived last before the given timestamp
'closest': (default value as this is the most stable) retrieves the version snapshot that was archived on the dateTime closest (least time difference) to given timestamp